### PR TITLE
Use the custom env (and its shape directly) when reloading

### DIFF
--- a/OpenAI Custom Environment Reinforcement Learning.ipynb
+++ b/OpenAI Custom Environment Reinforcement Learning.ipynb
@@ -634,9 +634,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env = gym.make('CartPole-v0')\n",
+    "env = ShowerEnv()\n",
     "actions = env.action_space.n\n",
-    "states = env.observation_space.shape[0]\n",
+    "states = env.observation_space.shape\n",
     "model = build_model(states, actions)\n",
     "dqn = build_agent(model, actions)\n",
     "dqn.compile(Adam(lr=1e-3), metrics=['mae'])"


### PR DESCRIPTION
Hello Nick,

First of all; thank you for sharing all these videos and code snippets; they have been instrumental on wetting my toes in the realms of reinforcement learning.

I know this example is a bit old, but I really wanted to run it; so I matched all the library versions (thanks to the output of your `!pip` commands), yet I was getting odd errors when it tried the "4. Reloading Agent from Memory".

Looking at the code I noticed it isn't loading the custom env (but instead the `CartPole-v0`) and also it is doing an unnecessary slicing of `observation_space.shape`, which were causing the errors; possibly some copy/paste issue happened when you uploaded the example.

This PR applies the two changes I did that made it work on my environment; with those, everything runs smoothly!